### PR TITLE
adding a null check to try to prevent an NPE. hopefully resolving [JENKINS-24839]

### DIFF
--- a/src/main/java/com/base2services/jenkins/SqsBuildTrigger.java
+++ b/src/main/java/com/base2services/jenkins/SqsBuildTrigger.java
@@ -127,7 +127,7 @@ public class SqsBuildTrigger extends Trigger<AbstractProject> implements GitHubT
             for (SCM scm : scmList) {
                 addRepositories(r, scm);
             }
-        } else {
+        } else if (job != null) {
             addRepositories(r, job.getScm());
         }
         return r;

--- a/src/main/java/com/base2services/jenkins/SqsBuildTrigger.java
+++ b/src/main/java/com/base2services/jenkins/SqsBuildTrigger.java
@@ -120,7 +120,7 @@ public class SqsBuildTrigger extends Trigger<AbstractProject> implements GitHubT
     @Override
     public Set<GitHubRepositoryName> getGitHubRepositories() {
         Set<GitHubRepositoryName> r = new HashSet<GitHubRepositoryName>();
-        if (Hudson.getInstance().getPlugin("multiple-scms") != null
+        if (Hudson.getInstance().getPlugin("multiple-scms") != null && job != null
                 && job.getScm() instanceof MultiSCM) {
             MultiSCM multiSCM = (MultiSCM) job.getScm();
             List<SCM> scmList = multiSCM.getConfiguredSCMs();


### PR DESCRIPTION
I ran into the same issue and have attempted to resolve it. The build's tests pass and my instance of Jenkins is once again able to save configuration changes. I have not managed to trace back WHY the job is null, but this at least prevents this plugin from breaking configuration updates in my case. Hope this helps.