### PR TITLE
Proxy support for SQS client

### DIFF
--- a/src/main/java/com/base2services/jenkins/SqsProfile.java
+++ b/src/main/java/com/base2services/jenkins/SqsProfile.java
@@ -1,18 +1,25 @@
 package com.base2services.jenkins;
 
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.Protocol;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.AmazonSQSClient;
 import com.amazonaws.services.sqs.model.CreateQueueRequest;
 import hudson.Extension;
+import hudson.ProxyConfiguration;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import hudson.util.FormValidation;
 import hudson.util.Secret;
+import jenkins.model.Jenkins;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -31,6 +38,8 @@ public class SqsProfile extends AbstractDescribableImpl<SqsProfile> implements A
     static final String queueUrlRegex = "^https://sqs\\.(.+?)\\.amazonaws\\.com/(.+?)/(.+)$";
     static final Pattern endpointPattern = Pattern.compile("(sqs\\..+?\\.amazonaws\\.com)");
     private final boolean urlSpecified;
+    private static final Logger LOGGER = Logger.getLogger(SqsProfile.class.getName());
+
     private AmazonSQS client;
 
 
@@ -67,20 +76,47 @@ public class SqsProfile extends AbstractDescribableImpl<SqsProfile> implements A
 
     public AmazonSQS getSQSClient() {
         if (client == null) {
-            if (!this.awsUseRole) {
-                client = new AmazonSQSClient(this);
-            } else {
-                client = new AmazonSQSClient();
-            }
-            if (urlSpecified) {
-                Matcher endpointMatcher = endpointPattern.matcher(getSqsQueue());
-                if (endpointMatcher.find()) {
-                    String endpoint = endpointMatcher.group(1);
-                    client.setEndpoint(endpoint);
-                }
-            }
+            String endpoint = getEndpoint();
+
+            ClientConfiguration clientConfiguration = getClientConfiguration(endpoint);
+
+            client = new AmazonSQSClient(this, clientConfiguration);
+            client.setEndpoint(endpoint);
         }
         return client;
+    }
+
+    private String getEndpoint() {
+        String endpoint = "";
+        if (urlSpecified) {
+            Matcher endpointMatcher = endpointPattern.matcher(getSqsQueue());
+            if (endpointMatcher.find()) {
+                endpoint =  endpointMatcher.group(1);
+            }
+        }
+        LOGGER.info("Resolved SQS endpoint to: " + endpoint);
+        return endpoint;
+    }
+
+    private ClientConfiguration getClientConfiguration(String endpoint) {
+        final ClientConfiguration config = new ClientConfiguration();
+
+        Jenkins jenkins = Jenkins.getInstance();
+        if (jenkins == null) {
+            return config;
+        }
+        ProxyConfiguration proxyConfig = jenkins.proxy;
+        Proxy proxy = proxyConfig == null ? Proxy.NO_PROXY : proxyConfig.createProxy(endpoint);
+        if (!proxy.equals(Proxy.NO_PROXY) && proxy.address() instanceof InetSocketAddress) {
+            InetSocketAddress address = (InetSocketAddress) proxy.address();
+            config.setProxyHost(address.getHostName());
+            config.setProxyPort(address.getPort());
+            if (null != proxyConfig.getUserName()) {
+                config.setProxyUsername(proxyConfig.getUserName());
+                config.setProxyPassword(proxyConfig.getPassword());
+            }
+        }
+        return config;
     }
 
     public String getSqsQueue() {


### PR DESCRIPTION
Adds support for copying the Jenkins proxy config and applying it to the SQS Client. 

Based off of #9 - so should be rebased once it is merged.