### PR TITLE
use latest aws sdk

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,18 @@
         </developer>
     </developers>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-java-sdk-bom</artifactId>
+                <version>1.11.222</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>com.coravy.hudson.plugins.github</groupId>
@@ -54,8 +66,7 @@
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk</artifactId>
-            <version>1.3.26</version>
+            <artifactId>aws-java-sdk-sqs</artifactId>
         </dependency>
     </dependencies>
 
@@ -84,6 +95,6 @@
         </pluginRepository>
     </pluginRepositories>
 
-</project>  
-  
+</project>
+
 


### PR DESCRIPTION
Updates to the latest SDK. Some notable changes:

- Switched from the now-deprecated constructors to the new builders
    - These builders throw an error when they can't divine the region, so try to be smarter about that when given a URL. Clients using a queue name will have to provide an `AWS_DEFAULT_REGION` (or similar) environment variable to their instance.
    - Also, since we were matching against the standard service url, it seems all the `setEndpoint` was doing was adjusting the region, so that's now more explicit.
- Marked a few unserializable fields `transient` to avoid failures to serialize the descriptor when the sqs client has been previously referenced (e.g. in groovy scripts)


This builds on @joppa27's excellent work in #16, so I think that the IAM path (which I had not tested) should continue to work as they experienced it.