### PR TITLE
Pass SQS messages to webhook plugin

### DIFF
--- a/src/main/java/com/base2services/jenkins/SqsQueueHandler.java
+++ b/src/main/java/com/base2services/jenkins/SqsQueueHandler.java
@@ -87,8 +87,10 @@ public class SqsQueueHandler extends PeriodicWork {
                     String actualMessage = messageParser.extractActualGithubMessage(awsMessage);
                     LOGGER.fine("Actual Github Message: " + actualMessage);
 
-
-                    GHEvent event  = messageParser.getGithubEvent(awsMessage);
+                    GHEvent event = GHEvent.PUSH;
+                    if (awsMessage != actualMessage) {
+                        event = messageParser.getGithubEvent(awsMessage);
+                    }
                     LOGGER.fine("Github event type: " + event.toString());
 
                     switch (event) {


### PR DESCRIPTION
Prevents a null value error when an SQS message can be treated
as a SNS message which does not contain the expected
json payload